### PR TITLE
Fix name of `config.fish` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To start using `tere`, follow these steps:
     aliases["tere"] = _tere
     ```
 
-    For fish, put this in your `.config.fish`:
+    For fish, put this in your `config.fish`:
     ```sh
     function tere
         set --local result (/path/to/tere $argv)


### PR DESCRIPTION
[The configuration file for fish is located at `$XDG_CONFIG_HOME/fish/config.fish`.](https://fishshell.com/docs/current/language.html#configuration-files) This makes the name of the configuration file `config.fish`, not `.config.fish`.

This pull request simply removes the dot. It may also be worth it to use the full path of `~/.config/fish/config.fish` in the description instead of just the name of the file.