### PR TITLE
Update README.md about AUR installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ how to do it:
    - Install `tere` with [Homebrew](https://brew.sh) by running `brew install tere`.
    - Install `tere` with [Nix](https://nixos.org/) by running `nix-env -i tere`.
    - Install `tere` with [Cargo](https://www.rust-lang.org/tools/install) by running `cargo install tere`.
+   - Install `tere` with an [AUR helper](https://wiki.archlinux.org/title/AUR_helpers): `paru -S tere`
    - Build from source, see [below](#hacking).
 
 1. Configure your shell to `cd` to the folder printed by `tere` when it exits. It has to be usually done using a function or alias, since a subprocess cannot change the working directory of the parent. See instructions for your shell below.


### PR DESCRIPTION
`tere` is available in the AUR: https://aur.archlinux.org/packages/tere
