### PR TITLE
Update README.md about installation on Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ how to do it:
    - Install `tere` with [Homebrew](https://brew.sh) by running `brew install tere`.
    - Install `tere` with [Nix](https://nixos.org/) by running `nix-env -i tere`.
    - Install `tere` with [Cargo](https://www.rust-lang.org/tools/install) by running `cargo install tere`.
-   - Install `tere` with an [AUR helper](https://wiki.archlinux.org/title/AUR_helpers): `paru -S tere`
+   - Install `tere` with [Pacman](https://wiki.archlinux.org/title/pacman) by running: `pacman -S tere`
    - Build from source, see [below](#hacking).
 
 1. Configure your shell to `cd` to the folder printed by `tere` when it exits. It has to be usually done using a function or alias, since a subprocess cannot change the working directory of the parent. See instructions for your shell below.


### PR DESCRIPTION
`tere` is moved to the community repository: https://archlinux.org/packages/community/x86_64/tere/
