### PR TITLE
Reset terminal state in case of a panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 1.4.0 (unreleased)
 
 - Check if the app is being run for the first time (based on whether the history file exists, and a bit of additional simple logic), and if so, prompt the user to confirm that they have updated their shell configuration (Github #83)
-- Upgrade `clap` dependency to latest version (required to catch panic)
+- If the app panics/crashes, the terminal state is properly reset, so it shouldn't produce garbled ouptut anymore
+- Upgrade `clap` dependency to latest version
 - Small improvements to setup instructions and user manual
 - Footer error message is not cleared when search is updated, only when changing the folder
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,5 @@
+use crossterm::{cursor, execute, terminal};
 use std::io::Write;
-use crossterm::{
-    execute,
-    terminal,
-    cursor,
-};
 
 //TODO: rustfmt
 //TODO: clippy
@@ -29,7 +25,6 @@ mod panic_guard;
 use panic_guard::GuardWithHook;
 
 fn main() -> Result<(), TereError> {
-
     let cli_args = cli_args::get_cli_args()
         .try_get_matches()
         .unwrap_or_else(|err| {
@@ -44,7 +39,6 @@ fn main() -> Result<(), TereError> {
     //Now the mouse capture enabling (which is kind of similar) is handled there.
     execute!(std::io::stderr(), terminal::EnterAlternateScreen)?;
     let res: Result<std::path::PathBuf, TereError> = {
-
         // Use guards to ensure that we disable raw mode, show the cursor and leave the alternate
         // screen, even in the event of a panic. We are using unwrap quite liberally here, but the
         // guards should ensure that everything is handled correctly in the very unlikely event

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,8 @@ use ui::TereTui;
 mod error;
 use error::TereError;
 
+mod panic_guard;
+use panic_guard::GuardWithHook;
 
 fn main() -> Result<(), TereError> {
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ fn main() -> Result<(), TereError> {
     //TODO: should this alternate screen etc initialization (and teardown) be done by the UI?
     //Now the mouse capture enabling (which is kind of similar) is handled there.
     execute!(std::io::stderr(), terminal::EnterAlternateScreen)?;
-    let res = {
+    let res: Result<std::path::PathBuf, TereError> = {
         // We can use unwrap here, the guards will ensure that the panic is handled correctly.
         let _guard = GuardWithHook::new(|| execute!(std::io::stderr(), terminal::LeaveAlternateScreen).unwrap());
         execute!(std::io::stderr(), cursor::Hide).unwrap();
@@ -54,19 +54,17 @@ fn main() -> Result<(), TereError> {
             {
                 let _guard = GuardWithHook::new(|| terminal::disable_raw_mode().unwrap());
 
-    // we are now inside the alternate screen, so collect all errors and attempt
-    // to leave the alt screen in case of an error
+                // we are now inside the alternate screen, so collect all errors and attempt
+                // to leave the alt screen in case of an error
 
-    let mut stderr = std::io::stderr();
+                let mut stderr = std::io::stderr();
 
-    let res: Result<std::path::PathBuf, TereError> = stderr.flush().map_err(TereError::from)
-        .and_then(|_| TereSettings::parse_cli_args(&cli_args))
-        .and_then(|(settings, warnings)| { check_first_run_with_prompt(&settings, &mut stderr)?; Ok((settings, warnings)) })
-        .and_then(|(settings, warnings)| TereAppState::init(settings, &warnings))
-        .and_then(|state| TereTui::init(state, &mut stderr))
-        .and_then(|mut ui| ui.main_event_loop()); // actually run the app and return the final path
-
-    res
+                stderr.flush().map_err(TereError::from)
+                    .and_then(|_| TereSettings::parse_cli_args(&cli_args))
+                    .and_then(|(settings, warnings)| { check_first_run_with_prompt(&settings, &mut stderr)?; Ok((settings, warnings)) })
+                    .and_then(|(settings, warnings)| TereAppState::init(settings, &warnings))
+                    .and_then(|state| TereTui::init(state, &mut stderr))
+                    .and_then(|mut ui| ui.main_event_loop()) // actually run the app and return the final path
             }
         }
     };

--- a/src/panic_guard.rs
+++ b/src/panic_guard.rs
@@ -1,0 +1,121 @@
+use std::sync::Arc;
+
+type PanicHookType = (dyn for<'r, 's> Fn(&'r std::panic::PanicInfo<'s>) + Send + Sync + 'static);
+
+/// Custom scopeguard-like struct that wraps a panic hook function and a callback ("cleanup")
+/// function, and in the case of a panic, calls the callback *before* the wrapped panic hook (i.e.
+/// printing the error message to stderr). We need this to e.g. switch back to the non-alternate
+/// screen before printing the error message, so that it doesn't disappear into the alternate
+/// screen.
+pub struct GuardWithHook<F>
+where
+    F: Fn() + Sync + Send + 'static,
+{
+    original_hook: Arc<PanicHookType>,
+    callback: Arc<F>,
+}
+
+impl<F> GuardWithHook<F>
+where
+    F: Fn() + Sync + Send + 'static,
+{
+    /// Store a callback function and the current panic hook, and install a new panic hook that
+    /// first calls the callback, and then the original.
+    fn new(callback: F) -> Self {
+        let callback = Arc::new(callback);
+        let callback_copy = callback.clone();
+
+        let original_hook: Arc<PanicHookType> = Arc::from(std::panic::take_hook());
+        let original_hook_copy = original_hook.clone();
+
+        std::panic::set_hook(Box::new(move |info| {
+            //(*callback_copy)();
+            (*original_hook_copy)(info);
+        }));
+
+        Self {
+            original_hook,
+            callback,
+        }
+    }
+}
+
+impl<F> Drop for GuardWithHook<F>
+where
+    F: Fn() + Sync + Send + 'static,
+{
+    /// Restore the original panic hook, and call the callback.
+    fn drop(&mut self) {
+        if !std::thread::panicking() {
+            // Set the panic hook back to what it was before. Note that this can be done only if
+            // we're not panicking.
+            let original_hook = self.original_hook.clone();
+            std::panic::set_hook(Box::new(move |info| (*original_hook)(info)));
+
+            // Only call the callback if we're not panicking, otherwise it has already been called
+            // by the panic hook.
+            (self.callback)();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // Need these to communicate results back to us from within callback
+    use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+    use std::sync::Mutex;
+
+    #[test]
+    fn test_callback_called_on_drop() {
+        let called = Arc::new(Mutex::new(0));
+
+        {
+            let called = called.clone();
+            let _guard = GuardWithHook::new(move || {*called.lock().unwrap() += 1;});
+            // guard is dropped, should call hook
+        }
+
+        assert_eq!(*called.lock().unwrap(), 1);
+    }
+
+    #[test]
+    fn test_panic() {
+        // because we're messing with the global panic hook, all tests have to be in one function
+        // to ensure that we're not modifying it from multiple different threads (unless we want to
+        // run the tests single-threaded).
+
+        // test that the callback is only called once, even if there is a panic
+        //let calls = Arc::new(Mutex::new(0));
+        //{
+        //    let calls = calls.clone();
+        //    let _guard = GuardWithHook::new(move || {*calls.lock().unwrap() += 1;});
+
+        //    assert!(std::panic::catch_unwind(|| panic!("test")).is_err());
+        //}
+        //assert_eq!(*calls.lock().unwrap(), 1);
+
+        // test that the callback is called before the panic hook
+
+        let original_hook = std::panic::take_hook(); // this should be the default hook
+
+        let calls: Arc<Mutex<Vec<&str>>> = Arc::new(Mutex::new(vec![]));
+        let calls2 = calls.clone();
+        std::panic::set_hook(Box::new(move |info| {
+            if let Ok(mut v) = calls2.try_lock() {
+                v.push("hook");
+            }
+            eprintln!("{}", info);
+        }));
+        {
+            let calls = calls.clone();
+            let _guard = GuardWithHook::new(move || {calls.lock().unwrap().push("cleanup");});
+
+            assert!(std::panic::catch_unwind(|| panic!("test")).is_err());
+        }
+        assert_eq!(*calls.lock().unwrap(), vec!["cleanup", "hook"]);
+
+        std::panic::set_hook(original_hook);
+    }
+
+}

--- a/src/panic_guard.rs
+++ b/src/panic_guard.rs
@@ -29,7 +29,7 @@ where
         let original_hook_copy = original_hook.clone();
 
         std::panic::set_hook(Box::new(move |info| {
-            //(*callback_copy)();
+            (*callback_copy)();
             (*original_hook_copy)(info);
         }));
 

--- a/src/panic_guard.rs
+++ b/src/panic_guard.rs
@@ -22,7 +22,7 @@ where
 {
     /// Store a callback function and the current panic hook, and install a new panic hook that
     /// first calls the callback, and then the original panic hook.
-    fn new(callback: F) -> Self {
+    pub fn new(callback: F) -> Self {
         let callback = Arc::new(Mutex::new(Some(callback)));
         let callback_copy = callback.clone();
 


### PR DESCRIPTION
So that we don't get garbled output in the case of a crash.

This is done using a custom struct that calls terminal cleanup functions on drop, similar to `scopeguard`, but it ensures that the panic hook (i.e. printing the error message) is done *after* the cleanup, so that the error message is not lost in the alternate screen.