### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.4.0 (2023-01-08)
 
 - Check if the app is being run for the first time (based on whether the history file exists, and a bit of additional simple logic), and if so, prompt the user to confirm that they have updated their shell configuration (Github #83)
-- If the app panics/crashes, the terminal state is properly reset, so it shouldn't produce garbled ouptut anymore
+- If the app panics/crashes, the terminal state is properly reset, so it shouldn't produce garbled output anymore
 - Upgrade `clap` dependency to latest version
 - Small improvements to setup instructions and user manual
 - Footer error message is not cleared when search is updated, only when changing the folder

--- a/src/first_run_check.rs
+++ b/src/first_run_check.rs
@@ -31,7 +31,7 @@ pub fn check_first_run_with_prompt(
 
     // For now we use a bit of a heuristic to determine if the app is being run for the first time:
     // we assume that the app has been run before if the history file exists, or the user
-    // explicitly requests no history file. (Or one more possiblity is that the cache directory
+    // explicitly requests no history file. (Or one more possibility is that the cache directory
     // doesn't exist. In this case, we assume that the user knows what they're doing, and don't
     // prompt either.)
     //

--- a/src/panic_guard.rs
+++ b/src/panic_guard.rs
@@ -194,7 +194,7 @@ mod tests {
                 let _g =
                     GuardWithHook::new(move || calls4.lock().unwrap().push("inner inner cleanup"));
 
-                // just for kicks, overwrite the panic hook here to check that it get's
+                // just for kicks, overwrite the panic hook here to check that it gets
                 // overwritten when guard is dropped
                 std::panic::set_hook(Box::new(move |_| calls5.lock().unwrap().push("wrong")));
             }


### PR DESCRIPTION
Found via `codespell -L crate,ser,noice,fo`