### PR TITLE
Properly handle final path errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.5.1 (unreleased)
 
+- Fix output formatting when exiting the app without cd, or when canceling the first run prompt (Thanks @orhun, Github #91, #92)
 - Update dependencies
 - Improved tests
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,12 +66,14 @@ fn main() -> Result<(), TereError> {
                         Ok((settings, warnings))
                     })?;
 
-                let final_path = TereAppState::init(settings, &warnings)
+                match TereAppState::init(settings, &warnings)
                     .and_then(|state| TereTui::init(state, &mut stderr))
                     // actually run the app and return the final path
-                    .and_then(|mut ui| ui.main_event_loop())?;
-
-                Ok((final_path, warnings))
+                    .and_then(|mut ui| ui.main_event_loop())
+                {
+                    Ok(final_path) => Ok((final_path, warnings)),
+                    Err(e) => Err(e),
+                }
             }
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,24 +56,21 @@ fn main() -> Result<(), TereError> {
                 // enabled. We can finally actually run the application.
 
                 let mut stderr = std::io::stderr();
-
-                let (settings, warnings) = stderr
+                stderr
                     .flush()
                     .map_err(TereError::from)
                     .and_then(|_| TereSettings::parse_cli_args(&cli_args))
                     .and_then(|(settings, warnings)| {
                         check_first_run_with_prompt(&settings, &mut stderr)?;
                         Ok((settings, warnings))
-                    })?;
-
-                match TereAppState::init(settings, &warnings)
-                    .and_then(|state| TereTui::init(state, &mut stderr))
-                    // actually run the app and return the final path
-                    .and_then(|mut ui| ui.main_event_loop())
-                {
-                    Ok(final_path) => Ok((final_path, warnings)),
-                    Err(e) => Err(e),
-                }
+                    })
+                    .and_then(|(settings, warnings)| {
+                        TereAppState::init(settings, &warnings)
+                            .and_then(|state| TereTui::init(state, &mut stderr))
+                            // actually run the app and return the final path
+                            .and_then(|mut ui| ui.main_event_loop())
+                            .map(|final_path| (final_path, warnings))
+                    })
             }
         }
     };


### PR DESCRIPTION
Fixes #91

The thing is, when the question mark is operator is used, the error is returned to `main`:

https://github.com/mgunyho/tere/blob/8a97cd4f36c4a4c91bbb1eed6caf5496a4849eb3/src/main.rs#L69-L72

Thus the next error handling part is never executed:

https://github.com/mgunyho/tere/blob/8a97cd4f36c4a4c91bbb1eed6caf5496a4849eb3/src/main.rs#L80-L96

This PR removes the question mark operator and uses the good old match arms to return the error to the actual scope.
