### PR TITLE
Add skip first run prompt cli flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Add a cli flag named `--skip-first-run-prompt` that disables the welcome message shown on the first launch of tere, which prompts the user to update their shell configuration for proper directory changing functionality.
 - Update dependencies
 
 ## 1.5.1 (2023-08-24)

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -250,6 +250,12 @@ justify_and_indent(
              .default_value("off")
              .overrides_with("mouse")
             )
+        .arg(Arg::new("skip-first-run-prompt")
+            .action(ArgAction::SetTrue)
+            .long("skip-first-run-prompt")
+            .help("Skip the first run prompt")
+            .long_help("Disables the welcome message shown on the first launch of tere, which prompts the user to update their shell configuration for proper directory changing functionality. Use this flag if you have already configured your shell or want to bypass the prompt for other reasons.")
+            )
 }
 
 /// Justify the list of enum variants (i.e. `ALL_ACTIONS` or `ALL_CONTEXTS`) and their

--- a/src/first_run_check.rs
+++ b/src/first_run_check.rs
@@ -27,6 +27,12 @@ pub fn check_first_run_with_prompt(
     settings: &TereSettings,
     window: &mut Stderr,
 ) -> Result<(), TereError> {
+    // If the user has explicitly requested to skip the first run promt, then we don't need to
+    // determine if the app is being run for the first time and return early.
+    if settings.skip_first_run_prompt {
+        return Ok(());
+    }
+
     let hist_file = &settings.history_file;
 
     // For now we use a bit of a heuristic to determine if the app is being run for the first time:

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -137,6 +137,8 @@ pub struct TereSettings {
     pub mouse_enabled: bool,
 
     pub keymap: HashMap<(KeyEvent, ActionContext), Action>,
+
+    pub skip_first_run_prompt: bool,
 }
 
 pub type DeprecationWarnings = Vec<&'static str>;
@@ -266,6 +268,10 @@ impl TereSettings {
             .get_one::<SortMode>("sort")
             .cloned()
             .unwrap_or_default();
+
+        if args.get_flag("skip-first-run-prompt") {
+            ret.skip_first_run_prompt = true;
+        }
 
         Ok((ret, warnings))
     }
@@ -849,6 +855,20 @@ mod tests {
         ]);
         assert!(!settings.mouse_enabled);
 
+    }
+
+    #[test]
+    fn test_skip_first_run_prompt() {
+        let settings = parse_cli_no_warnings(vec![
+            "foo",
+        ]);
+        assert!(!settings.skip_first_run_prompt);
+
+        let settings = parse_cli_no_warnings(vec![
+            "foo",
+            "--skip-first-run-prompt",
+        ]);
+        assert!(settings.skip_first_run_prompt);
     }
 
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -138,4 +138,31 @@ fn first_run_prompt_accept() -> Result<(), RexpectError> {
 
     Ok(())
 }
+
+#[test]
+fn skip_first_run_prompt() -> Result<(), RexpectError> {
+    let mut cmd = get_cmd();
+
+    // set the XDG_CACHE_HOME to point to a temporary folder so that we always get the first run prompt
+    let tmp = tempdir().expect("error creating temporary folder");
+    cmd.env("XDG_CACHE_HOME", tmp.path().as_os_str())
+        .current_dir(tmp.path())
+        .env("PWD", tmp.path())
+        .args(["--skip-first-run-prompt"]);
+
+    let mut proc = run_app_with_cmd(cmd);
+
+    // 0x1b = escape
+    proc.send("\x1b")?;
+    proc.writer.flush()?;
+
+    let output = proc.exp_eof()?;
+
+    let ptn = Regex::new("It seems like you are running.*for the first time").unwrap();
+    // check that first run prompt message was not printed
+    assert!(ptn.find(&output).is_none());
+
+    assert!(tmp.path().join("tere").join("history.json").exists());
+
+    Ok(())
 }


### PR DESCRIPTION
Adds a `--skip-first-run-prompt` flag.
"Disables the welcome message shown on the first launch of tere, which prompts the user to update their shell configuration for proper directory changing functionality. Use this flag if you have already configured your shell or want to bypass the prompt for other reasons."

See https://github.com/timon-schelling/tere/commit/eba404900fb2fcf74f150d3ff97ce382bf1e34aa#comments for the discussion that lead up to this.

@mgunyho The first commit contains all feature relevant code.
In the second commit I've updated the textwarp dependency, otherwise I'm not able to build master or this pr. error on master:
```
error[E0635]: unknown feature `stdsimd`
  --> /home/codespace/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ahash-0.7.6/src/lib.rs:33:42
   |
33 | #![cfg_attr(feature = "stdsimd", feature(stdsimd))]
   |                                          ^^^^^^^

For more information about this error, try `rustc --explain E0635`.
error: could not compile `ahash` (lib) due to 1 previous error
```

After updating textwarp I get a failing test both on main plus the second commit and for this pr.
`RUST_BACKTRACE=1 cargo test --no-fail-fast --locked`:
```
failures:

---- app_state::tests::test_case_sensitive_mode_change stdout ----
thread 'app_state::tests::test_case_sensitive_mode_change' panicked at src/app_state.rs:1711:9:
assertion `left == right` failed
  left: [1]
 right: [2]
stack backtrace:
   0: rust_begin_unwind
             at /rustc/c2f74c3f928aeb503f15b4e9ef5778e77f3058b8/library/std/src/panicking.rs:665:5
   1: core::panicking::panic_fmt
             at /rustc/c2f74c3f928aeb503f15b4e9ef5778e77f3058b8/library/core/src/panicking.rs:74:14
   2: core::panicking::assert_failed_inner
   3: core::panicking::assert_failed
             at /rustc/c2f74c3f928aeb503f15b4e9ef5778e77f3058b8/library/core/src/panicking.rs:367:5
   4: tere::app_state::tests::test_case_sensitive_mode_change
             at ./src/app_state.rs:1711:9
   5: tere::app_state::tests::test_case_sensitive_mode_change::{{closure}}
             at ./src/app_state.rs:1696:41
   6: core::ops::function::FnOnce::call_once
             at /rustc/c2f74c3f928aeb503f15b4e9ef5778e77f3058b8/library/core/src/ops/function.rs:250:5
   7: core::ops::function::FnOnce::call_once
             at /rustc/c2f74c3f928aeb503f15b4e9ef5778e77f3058b8/library/core/src/ops/function.rs:250:5
```

I guess this could be a rustc version mismatch but I'm not sure. What rustc version are you building against? Is this test working on master for you?